### PR TITLE
Remove Logging Messages at Import Time

### DIFF
--- a/alphatims/bruker.py
+++ b/alphatims/bruker.py
@@ -998,9 +998,6 @@ class TimsTOF(object):
                 "observed for some samples!"
             )
             logging.info("")
-        
-        #Create temporary folder containing temp mmapped arrays
-        tm.make_temp_dir()
 
         if bruker_d_folder_name.endswith("/"):
             bruker_d_folder_name = bruker_d_folder_name[:-1]

--- a/alphatims/bruker.py
+++ b/alphatims/bruker.py
@@ -29,17 +29,7 @@ elif sys.platform[:5] == "linux":
         "timsdata.so"
     )
 else:
-    logging.warning(
-        "WARNING: "
-        "No Bruker libraries are available for this operating system. "
-        "Mobility and m/z values need to be estimated. "
-        "While this estimation often returns acceptable results with errors "
-        "< 0.02 Th, huge errors (e.g. offsets of 6 Th) have already been "
-        "observed for some samples!"
-    )
-    logging.info("")
     BRUKER_DLL_FILE_NAME = ""
-
 
 def init_bruker_dll(bruker_dll_file_name: str = BRUKER_DLL_FILE_NAME):
     """Open a bruker.dll in Python.
@@ -996,6 +986,22 @@ class TimsTOF(object):
             This is ignored if the polarity is dropped.
             Default is True.
         """
+        
+        #Log a warning if there was not a valid DLL filename
+        if BRUKER_DLL_FILE_NAME=="":
+            logging.warning(
+                "WARNING: "
+                "No Bruker libraries are available for this operating system. "
+                "Mobility and m/z values need to be estimated. "
+                "While this estimation often returns acceptable results with errors "
+                "< 0.02 Th, huge errors (e.g. offsets of 6 Th) have already been "
+                "observed for some samples!"
+            )
+            logging.info("")
+        
+        #Create temporary folder containing temp mmapped arrays
+        tm.make_temp_dir()
+
         if bruker_d_folder_name.endswith("/"):
             bruker_d_folder_name = bruker_d_folder_name[:-1]
         logging.info(f"Importing data from {bruker_d_folder_name}")

--- a/alphatims/tempmmap.py
+++ b/alphatims/tempmmap.py
@@ -15,6 +15,9 @@ import numpy as np
 # local
 import alphatims.utils
 
+ARRAYS = {}
+CLOSED = False
+ALLOW_NDARRAY_SUBCLASS = False
 
 def make_temp_dir(prefix: str = "temp_mmap_") -> tuple:
     """Make a temporary directory.
@@ -31,21 +34,15 @@ def make_temp_dir(prefix: str = "temp_mmap_") -> tuple:
     """
     _temp_dir = tempfile.TemporaryDirectory(prefix=prefix)
     temp_dir_name = _temp_dir.name
-    return _temp_dir, temp_dir_name
-
-
-_TEMP_DIR, TEMP_DIR_NAME = make_temp_dir()
-ARRAYS = {}
-CLOSED = False
-ALLOW_NDARRAY_SUBCLASS = False
-
-logging.warning(
-    f"WARNING: Temp mmap arrays are written to {TEMP_DIR_NAME}. "
+    
+    logging.warning(
+    f"WARNING: Temp mmap arrays are written to {temp_dir_name}. "
     "Cleanup of this folder is OS dependant, "
     "and might need to be triggered manually! "
-    f"Current space: {shutil.disk_usage(TEMP_DIR_NAME)[-1]:,}"
+    f"Current space: {shutil.disk_usage(temp_dir_name)[-1]:,}"
 )
-
+    
+    return _temp_dir, temp_dir_name
 
 def empty(shape: tuple, dtype: np.dtype) -> np.ndarray:
     """Create a writable temporary mmapped array.

--- a/alphatims/tempmmap.py
+++ b/alphatims/tempmmap.py
@@ -15,9 +15,6 @@ import numpy as np
 # local
 import alphatims.utils
 
-ARRAYS = {}
-CLOSED = False
-ALLOW_NDARRAY_SUBCLASS = False
 
 def make_temp_dir(prefix: str = "temp_mmap_") -> tuple:
     """Make a temporary directory.
@@ -34,15 +31,13 @@ def make_temp_dir(prefix: str = "temp_mmap_") -> tuple:
     """
     _temp_dir = tempfile.TemporaryDirectory(prefix=prefix)
     temp_dir_name = _temp_dir.name
-    
-    logging.warning(
-    f"WARNING: Temp mmap arrays are written to {temp_dir_name}. "
-    "Cleanup of this folder is OS dependant, "
-    "and might need to be triggered manually! "
-    f"Current space: {shutil.disk_usage(temp_dir_name)[-1]:,}"
-)
-    
     return _temp_dir, temp_dir_name
+
+
+_TEMP_DIR, TEMP_DIR_NAME = make_temp_dir()
+ARRAYS = {}
+CLOSED = False
+ALLOW_NDARRAY_SUBCLASS = False
 
 def empty(shape: tuple, dtype: np.dtype) -> np.ndarray:
     """Create a writable temporary mmapped array.
@@ -269,6 +264,14 @@ def reset() -> str:
     del _TEMP_DIR
     _TEMP_DIR, TEMP_DIR_NAME = make_temp_dir()
     ARRAYS = {}
+    
+    logging.warning(
+    f"WARNING: Temp mmap arrays were written to {TEMP_DIR_NAME}. "
+    "Cleanup of this folder is OS dependant, "
+    "and might need to be triggered manually! "
+    f"Current space: {shutil.disk_usage(TEMP_DIR_NAME)[-1]:,}"
+    )
+    
     return TEMP_DIR_NAME
 
 


### PR DESCRIPTION
When parallelizing loading operations in a Ray environment, external libraries are automatically imported in external workers/subprocesses. Since some warnings/info were logged on import (i.e., before there's been a chance to manually define logger filters/limits in the new subprocesses), this produced unnecessary clutter in the terminal/console. Moving the applicable calls to prevent their immediate execution at import time solves this issue. 