### PR TITLE
(wip) added dockerfile and cicd to publish the image

### DIFF
--- a/.github/workflows/publish_and_release.yml
+++ b/.github/workflows/publish_and_release.yml
@@ -6,6 +6,10 @@ on:
 
 name: Publish on PyPi and release on GitHub
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: MannLabs/alphatims
+
 jobs:
   Version_Bumped:
     runs-on: ubuntu-latest
@@ -193,6 +197,49 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+  Create_Docker_Release:
+    # Adapted from wfondrie/mokapot's docker actions
+    runs-on: ubuntu-latest
+    needs: [Create_Linux_Release]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Build Wheel
+        run: |
+          python setup.py bdist_wheel
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to the GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Push the Docker image to the GHCR
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   Test_PyPi_Release:
     name: Test_PyPi_version_on_${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ COPY dist/*.whl /app/
 # RUN python3 -m pip install ".[plotting-stable]" # Image is 1.6gb with plotting
 # The size is reduced to 847 mb without it.
 RUN python3 -m pip install /app/*.whl
-# RUN python3 -m pip cache purge
+RUN python3 -m pip cache purge
 
 ENTRYPOINT [ "alphatims" ]
-
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+
+FROM python:3.9-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y build-essential gcc python3-dev
+COPY dist/*.whl /app/
+
+# RUN python3 -m pip install ".[plotting-stable]" # Image is 1.6gb with plotting
+# The size is reduced to 847 mb without it.
+RUN python3 -m pip install /app/*.whl
+# RUN python3 -m pip cache purge
+
+ENTRYPOINT [ "alphatims" ]
+
+
+


### PR DESCRIPTION
This PR adds a docker image for the package and CICD to publish it.

Discussed here:
https://github.com/MannLabs/alphatims/issues/256

LMK what you think. There are several ways to go around the CICD that I think should be design decisions with the team (whether to build the image and test the Dockerfile, whether to include the plotting dependencies, scope of the documentation ...)

Let me know which of those you feel would be what the project as a whole wants and we can work together in finishing those details!

Best,
Sebastian