### PR TITLE
Improve mmap

### DIFF
--- a/.github/workflows/pip_installation.yml
+++ b/.github/workflows/pip_installation.yml
@@ -47,9 +47,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
         with:
+          miniconda-version: "latest"
           auto-update-conda: true
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pip_installation.yml
+++ b/.github/workflows/pip_installation.yml
@@ -50,7 +50,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          miniconda-version: "latest"
           auto-update-conda: true
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Check out the [paper](https://doi.org/10.1016/j.mcpro.2021.100149).
 ---
 ## How to contribute
 
-If you like AlphaTims you can give us a [star](stargazers) to boost our visibility! All direct contributions are also welcome. Feel free to post a new [issue](https://github.com/MannLabs/alphabase/issues) or clone the repository and create a [pull request](https://github.com/MannLabs/alphabase/pulls) with a new branch. For an even more interactive participation, check out the [discussions](https://github.com/MannLabs/alphabase/discussions).
+If you like AlphaTims you can give us a [star](stargazers) to boost our visibility! All direct contributions are also welcome. Feel free to post a new [issue](https://github.com/MannLabs/alphatims/issues) or clone the repository and create a [pull request](https://github.com/MannLabs/alphabase/pulls) with a new branch. For an even more interactive participation, check out the [discussions](https://github.com/MannLabs/alphabase/discussions).
 For more information see [the Contributors License Agreement](misc/CLA.md).
 
 ---

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Check out the [paper](https://doi.org/10.1016/j.mcpro.2021.100149).
 ---
 ## How to contribute
 
-If you like AlphaTims you can give us a [star](stargazers) to boost our visibility! All direct contributions are also welcome. Feel free to post a new [issue](https://github.com/MannLabs/alphatims/issues) or clone the repository and create a [pull request](https://github.com/MannLabs/alphatims/pulls) with a new branch. For an even more interactive participation, check out the [discussions](https://github.com/MannLabs/alphabase/discussions).
+If you like AlphaTims you can give us a [star](stargazers) to boost our visibility! All direct contributions are also welcome. Feel free to post a new [issue](https://github.com/MannLabs/alphatims/issues) or clone the repository and create a [pull request](https://github.com/MannLabs/alphatims/pulls) with a new branch. For an even more interactive participation, check out the [discussions](https://github.com/MannLabs/alphatims/discussions).
 For more information see [the Contributors License Agreement](misc/CLA.md).
 
 ---

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Check out the [paper](https://doi.org/10.1016/j.mcpro.2021.100149).
 ---
 ## How to contribute
 
-If you like AlphaTims you can give us a [star](stargazers) to boost our visibility! All direct contributions are also welcome. Feel free to post a new [issue](https://github.com/MannLabs/alphatims/issues) or clone the repository and create a [pull request](https://github.com/MannLabs/alphabase/pulls) with a new branch. For an even more interactive participation, check out the [discussions](https://github.com/MannLabs/alphabase/discussions).
+If you like AlphaTims you can give us a [star](stargazers) to boost our visibility! All direct contributions are also welcome. Feel free to post a new [issue](https://github.com/MannLabs/alphatims/issues) or clone the repository and create a [pull request](https://github.com/MannLabs/alphatims/pulls) with a new branch. For an even more interactive participation, check out the [discussions](https://github.com/MannLabs/alphabase/discussions).
 For more information see [the Contributors License Agreement](misc/CLA.md).
 
 ---

--- a/alphatims/tempmmap.py
+++ b/alphatims/tempmmap.py
@@ -45,6 +45,13 @@ def make_temp_dir(prefix: str = "temp_mmap_") -> tuple:
     """
     _temp_dir = tempfile.TemporaryDirectory(prefix=prefix)
     temp_dir_name = _temp_dir.name
+
+    logging.info(
+        f"Memory-mapped arrays are written to temporary directory {temp_dir_name}. "
+        "Cleanup of this folder is OS dependent and might need to be triggered manually!"
+        f"Current space: {shutil.disk_usage(TEMP_DIR_NAME)[-1]:,}"
+    )
+
     return _temp_dir, temp_dir_name
 
 
@@ -241,18 +248,13 @@ def atexit_clear() -> str:
     """
     global CLOSED
     CLOSED = True
-    reset()
+    _reset()
 
 
-def reset() -> str:
+def _reset() -> str:
     """Reset the temporary folder containing temp mmapped arrays.
 
     WARNING: All existing temp mmapp arrays will become unusable!
-
-    Returns
-    -------
-    str
-        The name of the new temporary folder.
     """
     global _TEMP_DIR
     global TEMP_DIR_NAME
@@ -274,16 +276,27 @@ def reset() -> str:
         _memmap.close()
         del _memmap
     del _TEMP_DIR
+
+
+def reset() -> str:
+    """Reset the temporary folder containing temp mmapped arrays and create a new temporary folder.
+
+    WARNING: All existing temp mmapp arrays will become unusable!
+
+    Returns
+    -------
+    str
+        The name of the new temporary folder.
+    """
+    global _TEMP_DIR
+    global TEMP_DIR_NAME
+    global ARRAYS
+
+    _reset()
+
     _TEMP_DIR, TEMP_DIR_NAME = make_temp_dir()
     ARRAYS = {}
-    
-    logging.warning(
-    f"WARNING: Temp mmap arrays were written to {TEMP_DIR_NAME}. "
-    "Cleanup of this folder is OS dependant, "
-    "and might need to be triggered manually! "
-    f"Current space: {shutil.disk_usage(TEMP_DIR_NAME)[-1]:,}"
-    )
-    
+
     return TEMP_DIR_NAME
 
 

--- a/alphatims/tempmmap.py
+++ b/alphatims/tempmmap.py
@@ -261,7 +261,7 @@ def _reset() -> str:
     global ARRAYS
     global CLOSED
     if not CLOSED:
-        logging.warning(
+        logging.info(
             f"Folder {TEMP_DIR_NAME} with temp mmap arrays is being deleted. "
             "All existing temp mmapp arrays will be unusable!"
         )

--- a/alphatims/tempmmap.py
+++ b/alphatims/tempmmap.py
@@ -49,7 +49,7 @@ def make_temp_dir(prefix: str = "temp_mmap_") -> tuple:
     logging.info(
         f"Memory-mapped arrays are written to temporary directory {temp_dir_name}. "
         "Cleanup of this folder is OS dependent and might need to be triggered manually!"
-        f"Current space: {shutil.disk_usage(TEMP_DIR_NAME)[-1]:,}"
+        f"Current space: {shutil.disk_usage(temp_dir_name)[-1]:,}"
     )
 
     return _temp_dir, temp_dir_name

--- a/alphatims/utils.py
+++ b/alphatims/utils.py
@@ -166,8 +166,8 @@ def show_platform_info() -> None:
     # check if architecture is arm64 as psutil.cpu_freq() is not yet supported on apple silicon
     try:
         logging.info(f"cpu frequency - {psutil.cpu_freq().current:.2f} Mhz")
-    except AttributeError:
-        logging.info("Unable to log cpu frequency")
+    except Exception as e:
+        logging.info(f"Unable to log cpu frequency: {e}")
     logging.info(
         f"ram           - "
         f"{psutil.virtual_memory().available/1024**3:.1f}/"


### PR DESCRIPTION
Remove logic on module import:
- initialize temporary mmap dir only on demand
- do not initialize temporary mmap dir on reset

This caused slowing down unit tests of AlphaDIA as well as many log messages.

solves https://github.com/MannLabs/alphatims/issues/279